### PR TITLE
Update example.config.yml

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -3,7 +3,7 @@ admin_user: my-admin-user
 # To generate password on OS X: `openssl passwd -salt [salt] -1 [password]`.
 admin_password: my-generated-password
 admin_group: sudo
-admin_user_ssh_pubkey_file: /home/my-username/.ssh/id_ed25519.pub
+admin_user_ssh_pubkey_file: /home/my-username/.ssh/id_rsa.pub
 
 security_sudoers_passwordless: ['{{ admin_user }}']
 


### PR DESCRIPTION
changed sshkey name, in Ubuntu the default is "id_rsa.pub" not "id_ed25519.pub"